### PR TITLE
added hidden commands to menu bar

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -136,6 +136,15 @@
     <command>MI_RemoveSceneFrame</command>
     <command>MI_InsertGlobalKeyframe</command>
     <command>MI_RemoveGlobalKeyframe</command>
+    <separator/>
+    <command>MI_NextFrame</command>
+    <command>MI_PrevFrame</command>
+    <command>MI_FirstFrame</command>
+    <command>MI_LastFrame</command>
+    <command>MI_NextDrawing</command>
+    <command>MI_PrevDrawing</command>
+    <command>MI_NextStep</command>
+    <command>MI_PrevStep</command>
   </menu>
   <menu title="Cells">
     <command>MI_Reverse</command>
@@ -156,8 +165,11 @@
     <command>MI_Rollup</command>
     <command>MI_Rolldown</command>
     <command>MI_TimeStretch</command>
+    <separator/>
     <command>MI_DrawingSubForward</command>
     <command>MI_DrawingSubBackward</command>
+    <command>MI_DrawingSubGroupForward</command>
+    <command>MI_DrawingSubGroupBackward</command>
     <separator/>
     <command>MI_Autorenumber</command>
     <command>MI_Duplicate</command>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1726,6 +1726,14 @@ void MainWindow::defineActions() {
                          "");
   createMenuXsheetAction(MI_RemoveGlobalKeyframe, tr("Remove Multiple Keys"),
                          "");
+  createMenuXsheetAction(MI_FirstFrame, tr("First Frame"), "");
+  createMenuXsheetAction(MI_LastFrame, tr("Last Frame"), "");
+  createMenuXsheetAction(MI_PrevFrame, tr("Previous Frame"), "Shift+A");
+  createMenuXsheetAction(MI_NextFrame, tr("Next Frame"), "Shift+S");
+  createMenuXsheetAction(MI_NextDrawing, tr("Next Drawing"), "Shift+X");
+  createMenuXsheetAction(MI_PrevDrawing, tr("Prev Drawing"), "Shift+Z");
+  createMenuXsheetAction(MI_NextStep, tr("Next Step"), "");
+  createMenuXsheetAction(MI_PrevStep, tr("Prev Step"), "");
 
   createMenuCellsAction(MI_Reverse, tr("&Reverse"), "");
   createMenuCellsAction(MI_Swing, tr("&Swing"), "");
@@ -1829,17 +1837,17 @@ void MainWindow::defineActions() {
   createPlaybackAction(MI_Play, tr("Play"), "");
   createPlaybackAction(MI_Loop, tr("Loop"), "");
   createPlaybackAction(MI_Pause, tr("Pause"), "");
-  createPlaybackAction(MI_FirstFrame, tr("First Frame"), "");
-  createPlaybackAction(MI_LastFrame, tr("Last Frame"), "");
-  createPlaybackAction(MI_PrevFrame, tr("Previous Frame"), "Shift+A");
-  createPlaybackAction(MI_NextFrame, tr("Next Frame"), "Shift+S");
+  //createPlaybackAction(MI_FirstFrame, tr("First Frame"), "");
+  //createPlaybackAction(MI_LastFrame, tr("Last Frame"), "");
+  //createPlaybackAction(MI_PrevFrame, tr("Previous Frame"), "Shift+A");
+  //createPlaybackAction(MI_NextFrame, tr("Next Frame"), "Shift+S");
 
-  createAction(MI_NextDrawing, tr("Next Drawing"), "Shift+X",
-               PlaybackCommandType);
-  createAction(MI_PrevDrawing, tr("Prev Drawing"), "Shift+Z",
-               PlaybackCommandType);
-  createAction(MI_NextStep, tr("Next Step"), "", PlaybackCommandType);
-  createAction(MI_PrevStep, tr("Prev Step"), "", PlaybackCommandType);
+  //createAction(MI_NextDrawing, tr("Next Drawing"), "Shift+X",
+  //             PlaybackCommandType);
+  //createAction(MI_PrevDrawing, tr("Prev Drawing"), "Shift+Z",
+  //             PlaybackCommandType);
+  //createAction(MI_NextStep, tr("Next Step"), "", PlaybackCommandType);
+  //createAction(MI_PrevStep, tr("Prev Step"), "", PlaybackCommandType);
 
   createRGBAAction(MI_RedChannel, tr("Red Channel"), "");
   createRGBAAction(MI_GreenChannel, tr("Green Channel"), "");

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1231,6 +1231,15 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(xsheetMenu, MI_RemoveSceneFrame);
   addMenuItem(xsheetMenu, MI_InsertGlobalKeyframe);
   addMenuItem(xsheetMenu, MI_RemoveGlobalKeyframe);
+  xsheetMenu->addSeparator();
+  addMenuItem(xsheetMenu, MI_NextFrame);
+  addMenuItem(xsheetMenu, MI_PrevFrame);
+  addMenuItem(xsheetMenu, MI_FirstFrame);
+  addMenuItem(xsheetMenu, MI_LastFrame);
+  addMenuItem(xsheetMenu, MI_NextDrawing);
+  addMenuItem(xsheetMenu, MI_PrevDrawing);
+  addMenuItem(xsheetMenu, MI_NextStep);
+  addMenuItem(xsheetMenu, MI_PrevStep);
 
   // Menu' CELLS
   QMenu *cellsMenu = addMenu(tr("Cells"), fullMenuBar);
@@ -1252,8 +1261,11 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(cellsMenu, MI_Rollup);
   addMenuItem(cellsMenu, MI_Rolldown);
   addMenuItem(cellsMenu, MI_TimeStretch);
-  addMenuItem(xsheetMenu, MI_DrawingSubForward);
-  addMenuItem(xsheetMenu, MI_DrawingSubBackward);
+  cellsMenu->addSeparator();
+  addMenuItem(cellsMenu, MI_DrawingSubForward);
+  addMenuItem(cellsMenu, MI_DrawingSubBackward);
+  addMenuItem(cellsMenu, MI_DrawingSubGroupForward);
+  addMenuItem(cellsMenu, MI_DrawingSubGroupBackward);
   cellsMenu->addSeparator();
   addMenuItem(cellsMenu, MI_Autorenumber);
   addMenuItem(cellsMenu, MI_Duplicate);


### PR DESCRIPTION
#393 
- Added some hidden commands to xsheet and cells menu bar.  This aids in discoverability and shortcut learning.
XSheet (It's the commands at the end):
![xsheet](https://cloud.githubusercontent.com/assets/4576381/17090149/2db5fcb4-51eb-11e6-8f34-0973521b9b50.jpg)
Cells (It's the drawing substitution commands):
![cellsmenu](https://cloud.githubusercontent.com/assets/4576381/17090154/3637d7cc-51eb-11e6-99ba-c3d09fc931c6.jpg)

- Added these items to the menu bar customization window.  (I think anything you can remove, you should be able to add back)
![customize](https://cloud.githubusercontent.com/assets/4576381/17090165/5b864d38-51eb-11e6-8621-3b10156982dc.jpg)
